### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/src/gen-arabic-table.py
+++ b/src/gen-arabic-table.py
@@ -67,7 +67,7 @@ def print_joining_table(f):
 
 	print
 	for value,short in short_value.items():
-		print "#define %s	%s" % (short, value)
+		print "#define {0!s}	{1!s}".format(short, value)
 
 	uu = sorted(values.keys())
 	num = len(values)
@@ -90,7 +90,7 @@ def print_joining_table(f):
 	for start,end in ranges:
 
 		print
-		print "#define joining_offset_0x%04xu %d" % (start, offset)
+		print "#define joining_offset_0x{0:04x}u {1:d}".format(start, offset)
 
 		for u in range(start, end+1):
 
@@ -101,24 +101,24 @@ def print_joining_table(f):
 				if u != start:
 					print
 				if block in all_blocks:
-					print "\n  /* %s */" % block
+					print "\n  /* {0!s} */".format(block)
 				else:
 					print "\n  /* FILLER */"
 				last_block = block
 				if u % 32 != 0:
 					print
-					print "  /* %04X */" % (u//32*32), "  " * (u % 32),
+					print "  /* {0:04X} */".format((u//32*32)), "  " * (u % 32),
 
 			if u % 32 == 0:
 				print
-				print "  /* %04X */ " % u,
-			sys.stdout.write("%s," % short_value[value])
+				print "  /* {0:04X} */ ".format(u),
+			sys.stdout.write("{0!s},".format(short_value[value]))
 		print
 
 		offset += end - start + 1
 	print
 	occupancy = num * 100. / offset
-	print "}; /* Table items: %d; occupancy: %d%% */" % (offset, occupancy)
+	print "}}; /* Table items: {0:d}; occupancy: {1:d}% */".format(offset, occupancy)
 	print
 
 	page_bits = 12;
@@ -126,15 +126,15 @@ def print_joining_table(f):
 	print "static unsigned int"
 	print "joining_type (hb_codepoint_t u)"
 	print "{"
-	print "  switch (u >> %d)" % page_bits
+	print "  switch (u >> {0:d})".format(page_bits)
 	print "  {"
 	pages = set([u>>page_bits for u in [s for s,e in ranges]+[e for s,e in ranges]])
 	for p in sorted(pages):
-		print "    case 0x%0Xu:" % p
+		print "    case 0x{0:0X}u:".format(p)
 		for (start,end) in ranges:
 			if p not in [start>>page_bits, end>>page_bits]: continue
-			offset = "joining_offset_0x%04xu" % start
-			print "      if (hb_in_range (u, 0x%04Xu, 0x%04Xu)) return joining_table[u - 0x%04Xu + %s];" % (start, end, start, offset)
+			offset = "joining_offset_0x{0:04x}u".format(start)
+			print "      if (hb_in_range (u, 0x{0:04X}u, 0x{1:04X}u)) return joining_table[u - 0x{2:04X}u + {3!s}];".format(start, end, start, offset)
 		print "      break;"
 		print ""
 	print "    default:"
@@ -144,7 +144,7 @@ def print_joining_table(f):
 	print "}"
 	print
 	for value,short in short_value.items():
-		print "#undef %s" % (short)
+		print "#undef {0!s}".format((short))
 	print
 
 def print_shaping_table(f):
@@ -195,13 +195,13 @@ def print_shaping_table(f):
 	for u in range (min_u, max_u + 1):
 		s = [shapes[u][shape] if u in shapes and shape in shapes[u] else 0
 		     for shape in  ['initial', 'medial', 'final', 'isolated']]
-		value = ', '.join ("0x%04Xu" % c for c in s)
-		print "  {%s}, /* U+%04X %s */" % (value, u, names[u] if u in names else "")
+		value = ', '.join ("0x{0:04X}u".format(c) for c in s)
+		print "  {{{0!s}}}, /* U+{1:04X} {2!s} */".format(value, u, names[u] if u in names else "")
 
 	print "};"
 	print
-	print "#define SHAPING_TABLE_FIRST	0x%04Xu" % min_u
-	print "#define SHAPING_TABLE_LAST	0x%04Xu" % max_u
+	print "#define SHAPING_TABLE_FIRST	0x{0:04X}u".format(min_u)
+	print "#define SHAPING_TABLE_LAST	0x{0:04X}u".format(max_u)
 	print
 
 	ligas = {}
@@ -224,16 +224,16 @@ def print_shaping_table(f):
 	print " struct ligature_pairs_t {"
 	print "   uint16_t second;"
 	print "   uint16_t ligature;"
-	print " } ligatures[%d];" % max_i
+	print " }} ligatures[{0:d}];".format(max_i)
 	print "} ligature_table[] ="
 	print "{"
 	keys = ligas.keys ()
 	keys.sort ()
 	for first in keys:
 
-		print "  { 0x%04Xu, {" % (first)
+		print "  {{ 0x{0:04X}u, {{".format((first))
 		for liga in ligas[first]:
-			print "    { 0x%04Xu, 0x%04Xu }, /* %s */" % (liga[0], liga[1], names[liga[1]])
+			print "    {{ 0x{0:04X}u, 0x{1:04X}u }}, /* {2!s} */".format(liga[0], liga[1], names[liga[1]])
 		print "  }},"
 
 	print "};"
@@ -251,7 +251,7 @@ print " * on files with these headers:"
 print " *"
 for h in headers:
 	for l in h:
-		print " * %s" % (l.strip())
+		print " * {0!s}".format((l.strip()))
 print " */"
 print
 print "#ifndef HB_OT_SHAPE_COMPLEX_ARABIC_TABLE_HH"

--- a/src/gen-indic-table.py
+++ b/src/gen-indic-table.py
@@ -75,7 +75,7 @@ print " * on files with these headers:"
 print " *"
 for h in headers:
 	for l in h:
-		print " * %s" % (l.strip())
+		print " * {0!s}".format((l.strip()))
 print " */"
 print
 print '#include "hb-ot-shape-complex-indic-private.hh"'
@@ -121,8 +121,7 @@ for i in range (2):
 				raise Exception ("Duplicate short value alias", v, all_shorts[i][s])
 			all_shorts[i][s] = v
 			short[i][v] = s
-		print "#define %s_%s	%s_%s	%s/* %3d chars; %s */" % \
-			(what_short[i], s, what[i], v.upper (), \
+		print "#define {0!s}_{1!s}	{2!s}_{3!s}	{4!s}/* {5:3d} chars; {6!s} */".format(what_short[i], s, what[i], v.upper (), \
 			'	'* ((48-1 - len (what[i]) - 1 - len (v)) / 8), \
 			values[i][v], v)
 print
@@ -138,18 +137,18 @@ def print_block (block, start, end, data):
 	if block and block != last_block:
 		print
 		print
-		print "  /* %s */" % block
+		print "  /* {0!s} */".format(block)
 	num = 0
 	assert start % 8 == 0
 	assert (end+1) % 8 == 0
 	for u in range (start, end+1):
 		if u % 8 == 0:
 			print
-			print "  /* %04X */" % u,
+			print "  /* {0:04X} */".format(u),
 		if u in data:
 			num += 1
 		d = data.get (u, defaults)
-		sys.stdout.write ("%9s" % ("_(%s,%s)," % (short[0][d[0]], short[1][d[1]])))
+		sys.stdout.write ("{0:9!s}".format(("_({0!s},{1!s}),".format(short[0][d[0]], short[1][d[1]]))))
 
 	total += end - start + 1
 	used += num
@@ -186,7 +185,7 @@ for u in uu:
 				offset += ends[-1] - starts[-1]
 			print
 			print
-			print "#define indic_offset_0x%04xu %d" % (start, offset)
+			print "#define indic_offset_0x{0:04x}u {1:d}".format(start, offset)
 			starts.append (start)
 
 	print_block (block, start, end, data)
@@ -197,23 +196,23 @@ print
 print
 occupancy = used * 100. / total
 page_bits = 12
-print "}; /* Table items: %d; occupancy: %d%% */" % (offset, occupancy)
+print "}}; /* Table items: {0:d}; occupancy: {1:d}% */".format(offset, occupancy)
 print
 print "INDIC_TABLE_ELEMENT_TYPE"
 print "hb_indic_get_categories (hb_codepoint_t u)"
 print "{"
-print "  switch (u >> %d)" % page_bits
+print "  switch (u >> {0:d})".format(page_bits)
 print "  {"
 pages = set([u>>page_bits for u in starts+ends+singles.keys()])
 for p in sorted(pages):
-	print "    case 0x%0Xu:" % p
+	print "    case 0x{0:0X}u:".format(p)
 	for (start,end) in zip (starts, ends):
 		if p not in [start>>page_bits, end>>page_bits]: continue
-		offset = "indic_offset_0x%04xu" % start
-		print "      if (hb_in_range (u, 0x%04Xu, 0x%04Xu)) return indic_table[u - 0x%04Xu + %s];" % (start, end-1, start, offset)
+		offset = "indic_offset_0x{0:04x}u".format(start)
+		print "      if (hb_in_range (u, 0x{0:04X}u, 0x{1:04X}u)) return indic_table[u - 0x{2:04X}u + {3!s}];".format(start, end-1, start, offset)
 	for u,d in singles.items ():
 		if p != u>>page_bits: continue
-		print "      if (unlikely (u == 0x%04Xu)) return _(%s,%s);" % (u, short[0][d[0]], short[1][d[1]])
+		print "      if (unlikely (u == 0x{0:04X}u)) return _({1!s},{2!s});".format(u, short[0][d[0]], short[1][d[1]])
 	print "      break;"
 	print ""
 print "    default:"
@@ -228,8 +227,7 @@ for i in range (2):
 	vv = values[i].keys ()
 	vv.sort ()
 	for v in vv:
-		print "#undef %s_%s" % \
-			(what_short[i], short[i][v])
+		print "#undef {0!s}_{1!s}".format(what_short[i], short[i][v])
 print
 print "/* == End of generated table == */"
 

--- a/src/gen-use-table.py
+++ b/src/gen-use-table.py
@@ -297,7 +297,7 @@ def map_to_use(data):
 
 		evals = [(k, v(U,UISC,UGC)) for k,v in items]
 		values = [k for k,v in evals if v]
-		assert len(values) == 1, "%s %s %s %s" % (hex(U), UISC, UGC, values)
+		assert len(values) == 1, "{0!s} {1!s} {2!s} {3!s}".format(hex(U), UISC, UGC, values)
 		USE = values[0]
 
 		# Resolve Indic_Positional_Category
@@ -321,12 +321,12 @@ def map_to_use(data):
 		if 0x1CF8 <= U <= 0x1CF9: UIPC = Top
 
 		assert (UIPC in [Not_Applicable, Visual_Order_Left] or
-			USE in use_positions), "%s %s %s %s %s" % (hex(U), UIPC, USE, UISC, UGC)
+			USE in use_positions), "{0!s} {1!s} {2!s} {3!s} {4!s}".format(hex(U), UIPC, USE, UISC, UGC)
 
 		pos_mapping = use_positions.get(USE, None)
 		if pos_mapping:
 			values = [k for k,v in pos_mapping.items() if v and UIPC in v]
-			assert len(values) == 1, "%s %s %s %s %s %s" % (hex(U), UIPC, USE, UISC, UGC, values)
+			assert len(values) == 1, "{0!s} {1!s} {2!s} {3!s} {4!s} {5!s}".format(hex(U), UIPC, USE, UISC, UGC, values)
 			USE = USE + values[0]
 
 		out[U] = (USE, UBlock)
@@ -351,7 +351,7 @@ print " * on files with these headers:"
 print " *"
 for h in headers:
 	for l in h:
-		print " * %s" % (l.strip())
+		print " * {0!s}".format((l.strip()))
 print " */"
 print
 print '#include "hb-ot-shape-complex-use-private.hh"'
@@ -365,7 +365,7 @@ def print_block (block, start, end, data):
 	if block and block != last_block:
 		print
 		print
-		print "  /* %s */" % block
+		print "  /* {0!s} */".format(block)
 		if start % 16:
 			print ' ' * (20 + (start % 16 * 6)),
 	num = 0
@@ -374,11 +374,11 @@ def print_block (block, start, end, data):
 	for u in range (start, end+1):
 		if u % 16 == 0:
 			print
-			print "  /* %04X */" % u,
+			print "  /* {0:04X} */".format(u),
 		if u in data:
 			num += 1
 		d = data.get (u, defaults)
-		sys.stdout.write ("%6s," % d[0])
+		sys.stdout.write ("{0:6!s},".format(d[0]))
 
 	total += end - start + 1
 	used += num
@@ -395,12 +395,12 @@ starts = []
 ends = []
 for k,v in sorted(use_mapping.items()):
 	if k in use_positions and use_positions[k]: continue
-	print "#define %s	USE_%s	/* %s */" % (k, k, v.__name__[3:])
+	print "#define {0!s}	USE_{1!s}	/* {2!s} */".format(k, k, v.__name__[3:])
 for k,v in sorted(use_positions.items()):
 	if not v: continue
 	for suf in v.keys():
 		tag = k + suf
-		print "#define %s	USE_%s" % (tag, tag)
+		print "#define {0!s}	USE_{1!s}".format(tag, tag)
 print ""
 print "static const USE_TABLE_ELEMENT_TYPE use_table[] = {"
 for u in uu:
@@ -424,7 +424,7 @@ for u in uu:
 				offset += ends[-1] - starts[-1]
 			print
 			print
-			print "#define use_offset_0x%04xu %d" % (start, offset)
+			print "#define use_offset_0x{0:04x}u {1:d}".format(start, offset)
 			starts.append (start)
 
 	print_block (block, start, end, data)
@@ -435,23 +435,23 @@ print
 print
 occupancy = used * 100. / total
 page_bits = 12
-print "}; /* Table items: %d; occupancy: %d%% */" % (offset, occupancy)
+print "}}; /* Table items: {0:d}; occupancy: {1:d}% */".format(offset, occupancy)
 print
 print "USE_TABLE_ELEMENT_TYPE"
 print "hb_use_get_categories (hb_codepoint_t u)"
 print "{"
-print "  switch (u >> %d)" % page_bits
+print "  switch (u >> {0:d})".format(page_bits)
 print "  {"
 pages = set([u>>page_bits for u in starts+ends+singles.keys()])
 for p in sorted(pages):
-	print "    case 0x%0Xu:" % p
+	print "    case 0x{0:0X}u:".format(p)
 	for (start,end) in zip (starts, ends):
 		if p not in [start>>page_bits, end>>page_bits]: continue
-		offset = "use_offset_0x%04xu" % start
-		print "      if (hb_in_range (u, 0x%04Xu, 0x%04Xu)) return use_table[u - 0x%04Xu + %s];" % (start, end-1, start, offset)
+		offset = "use_offset_0x{0:04x}u".format(start)
+		print "      if (hb_in_range (u, 0x{0:04X}u, 0x{1:04X}u)) return use_table[u - 0x{2:04X}u + {3!s}];".format(start, end-1, start, offset)
 	for u,d in singles.items ():
 		if p != u>>page_bits: continue
-		print "      if (unlikely (u == 0x%04Xu)) return %s;" % (u, d[0])
+		print "      if (unlikely (u == 0x{0:04X}u)) return {1!s};".format(u, d[0])
 	print "      break;"
 	print ""
 print "    default:"
@@ -462,12 +462,12 @@ print "}"
 print
 for k in sorted(use_mapping.keys()):
 	if k in use_positions and use_positions[k]: continue
-	print "#undef %s" % k
+	print "#undef {0!s}".format(k)
 for k,v in sorted(use_positions.items()):
 	if not v: continue
 	for suf in v.keys():
 		tag = k + suf
-		print "#undef %s" % tag
+		print "#undef {0!s}".format(tag)
 print
 print "/* == End of generated table == */"
 

--- a/src/sample.py
+++ b/src/sample.py
@@ -55,4 +55,4 @@ for info,pos in zip(infos, positions):
 	x_offset = pos.x_offset
 	y_offset = pos.y_offset
 
-	print("gid%d=%d@%d,%d+%d" % (gid, cluster, x_advance, x_offset, y_offset))
+	print("gid{0:d}={1:d}@{2:d},{3:d}+{4:d}".format(gid, cluster, x_advance, x_offset, y_offset))

--- a/test/shaping/hb_test_tools.py
+++ b/test/shaping/hb_test_tools.py
@@ -41,7 +41,7 @@ class ColorFormatter:
 	class HTML:
 		@staticmethod
 		def start_color (c):
-			return '<span style="background:%s">' % c
+			return '<span style="background:{0!s}">'.format(c)
 		@staticmethod
 		def end_color ():
 			return '</span>'
@@ -146,7 +146,7 @@ class ZipDiffer:
 						sys.stdout.writelines ([symbols[i], l])
 		except IOError as e:
 			if e.errno != errno.EPIPE:
-				print ("%s: %s: %s" % (sys.argv[0], e.filename, e.strerror), file=sys.stderr)
+				print ("{0!s}: {1!s}: {2!s}".format(sys.argv[0], e.filename, e.strerror), file=sys.stderr)
 				sys.exit (1)
 
 
@@ -219,7 +219,7 @@ class DiffSinks:
 			else:
 				failed += 1
 		total = passed + failed
-		print ("%d out of %d tests passed.  %d failed (%g%%)" % (passed, total, failed, 100. * failed / total))
+		print ("{0:d} out of {1:d} tests passed.  {2:d} failed ({3:g}%)".format(passed, total, failed, 100. * failed / total))
 
 	@staticmethod
 	def print_ngrams (f, ns=(1,2,3)):
@@ -244,7 +244,7 @@ class DiffSinks:
 		del importantgrams
 
 		for ngram, stats in allgrams.iteritems ():
-			print ("zscore: %9f failed: %6d passed: %6d ngram: <%s>" % (stats.zscore (allstats), stats.failed.count, stats.passed.count, ','.join ("U+%04X" % u for u in ngram)))
+			print ("zscore: {0:9f} failed: {1:6d} passed: {2:6d} ngram: <{3!s}>".format(stats.zscore (allstats), stats.failed.count, stats.passed.count, ','.join ("U+{0:04X}".format(u) for u in ngram)))
 
 
 
@@ -348,7 +348,7 @@ class UtilMains:
 	def process_multiple_files (callback, mnemonic = "FILE"):
 
 		if "--help" in sys.argv:
-			print ("Usage: %s %s..." % (sys.argv[0], mnemonic))
+			print ("Usage: {0!s} {1!s}...".format(sys.argv[0], mnemonic))
 			sys.exit (1)
 
 		try:
@@ -357,14 +357,14 @@ class UtilMains:
 				callback (FileHelpers.open_file_or_stdin (s))
 		except IOError as e:
 			if e.errno != errno.EPIPE:
-				print ("%s: %s: %s" % (sys.argv[0], e.filename, e.strerror), file=sys.stderr)
+				print ("{0!s}: {1!s}: {2!s}".format(sys.argv[0], e.filename, e.strerror), file=sys.stderr)
 				sys.exit (1)
 
 	@staticmethod
 	def process_multiple_args (callback, mnemonic):
 
 		if len (sys.argv) == 1 or "--help" in sys.argv:
-			print ("Usage: %s %s..." % (sys.argv[0], mnemonic))
+			print ("Usage: {0!s} {1!s}...".format(sys.argv[0], mnemonic))
 			sys.exit (1)
 
 		try:
@@ -372,7 +372,7 @@ class UtilMains:
 				callback (s)
 		except IOError as e:
 			if e.errno != errno.EPIPE:
-				print ("%s: %s: %s" % (sys.argv[0], e.filename, e.strerror), file=sys.stderr)
+				print ("{0!s}: {1!s}: {2!s}".format(sys.argv[0], e.filename, e.strerror), file=sys.stderr)
 				sys.exit (1)
 
 	@staticmethod
@@ -381,8 +381,7 @@ class UtilMains:
 					      concat_separator = False):
 
 		if "--help" in sys.argv:
-			print ("Usage:\n  %s %s...\nor:\n  %s\n\nWhen called with no arguments, input is read from standard input." \
-			      % (sys.argv[0], mnemonic, sys.argv[0]))
+			print ("Usage:\n  {0!s} {1!s}...\nor:\n  {2!s}\n\nWhen called with no arguments, input is read from standard input.".format(sys.argv[0], mnemonic, sys.argv[0]))
 			sys.exit (1)
 
 		try:
@@ -401,7 +400,7 @@ class UtilMains:
 				print (separator.join (callback (x) for x in (args)))
 		except IOError as e:
 			if e.errno != errno.EPIPE:
-				print ("%s: %s: %s" % (sys.argv[0], e.filename, e.strerror), file=sys.stderr)
+				print ("{0!s}: {1!s}: {2!s}".format(sys.argv[0], e.filename, e.strerror), file=sys.stderr)
 				sys.exit (1)
 
 
@@ -409,7 +408,7 @@ class Unicode:
 
 	@staticmethod
 	def decode (s):
-		return u','.join ("U+%04X" % ord (u) for u in unicode (s, 'utf-8')).encode ('utf-8')
+		return u','.join ("U+{0:04X}".format(ord (u)) for u in unicode (s, 'utf-8')).encode ('utf-8')
 
 	@staticmethod
 	def parse (s):
@@ -477,7 +476,7 @@ class Manifest:
 
 		if not os.path.exists (s):
 			if strict:
-				print ("%s: %s does not exist" % (sys.argv[0], s), file=sys.stderr)
+				print ("{0!s}: {1!s} does not exist".format(sys.argv[0], s), file=sys.stderr)
 				sys.exit (1)
 			return
 
@@ -493,7 +492,7 @@ class Manifest:
 						yield p
 			except IOError:
 				if strict:
-					print ("%s: %s does not exist" % (sys.argv[0], os.path.join (s, "MANIFEST")), file=sys.stderr)
+					print ("{0!s}: {1!s} does not exist".format(sys.argv[0], os.path.join (s, "MANIFEST")), file=sys.stderr)
 					sys.exit (1)
 				return
 		else:
@@ -512,7 +511,7 @@ class Manifest:
 			dirnames.sort ()
 			filenames.sort ()
 			ms = os.path.join (dirpath, "MANIFEST")
-			print ("  GEN    %s" % ms)
+			print ("  GEN    {0!s}".format(ms))
 			m = open (ms, "w")
 			for f in filenames:
 				print (f, file=m)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:harfbuzz?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:harfbuzz?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
